### PR TITLE
set 2nd argument of \nomenclatureitem left-margined, fix #146

### DIFF
--- a/Style/artratex.sty
+++ b/Style/artratex.sty
@@ -505,7 +505,9 @@
 %-> Nomenclature item
 %-
 \providecommand{\nomenclatureitem}[3][ ]{%
-    \noindent\makebox[0.15\textwidth][l]{#2}{{#3}\hfill{#1}}\par
+  \settowidth{\@tempdima}{#1}%
+  \noindent\makebox[0.15\textwidth][l]{#2}%
+  \parbox[t]{\dimexpr .85\textwidth - \@tempdima - 2em}{\linespread{1.2}\selectfont #3}\hfill{#1}\par
 }
 %-
 %-> Macro for adding link to toc and bookmark


### PR DESCRIPTION
符号列表功能，可以考虑使用 `nomencl` 宏包、或者以表格的形式实现。